### PR TITLE
Refactor GHGrid rows and memoize cells

### DIFF
--- a/InputGrid.jsx
+++ b/InputGrid.jsx
@@ -5,7 +5,7 @@ import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
 import { Link } from 'react-router-dom';
-import { useMemo, useState } from 'react';
+import { useMemo, useState, useCallback } from 'react';
 import Guid from 'devextreme/core/guid';
 import { useSearchCodingQuery } from '@kara-erp/shared-lib-header-and-sidebar';
 import { useSearchDetailedAccountQuery } from '@kara-erp/shared-lib-header-and-sidebar';
@@ -46,7 +46,7 @@ export const InputGrid = ({
     notes: '',
     trackingNumber: '',
     trackingDate: null,
-  };
+  }, [i18n, t, codingSearchIsFetching, moeinAccountOpen, detailedOpen4, detailedOpen5, detailedOpen6, formik.values.documentArticles, documentArticlesFocusedRow]);
   function renderBalanceClassName() {
     if (creditsTotal > debitsTotal) {
       return 'balanceFieldGreen';
@@ -237,7 +237,7 @@ export const InputGrid = ({
       moeinAccountSearchFormik.setFieldValue('CompleteCode', value);
       moeinAccountSearchFormik.setFieldValue('FormersNames', '');
     }
-  };
+  }, [i18n, t, detailed4SearchIsFetching, moeinAccountOpen, detailedOpen4, detailedOpen5, detailedOpen6, formik.values.documentArticles, documentArticlesFocusedRow]);
   const debouncedHandleMoeinAccountChange = useMemo(
     () => debounce(moeinAccountSearchFormik.handleSubmit, 500),
     []
@@ -251,7 +251,7 @@ export const InputGrid = ({
       detailed4SearchFormik.setFieldValue('DetailedAccountCode', value);
       detailed4SearchFormik.setFieldValue('DetailedAccountName', '');
     }
-  };
+  }, [i18n, t, detailed5SearchIsFetching, moeinAccountOpen, detailedOpen4, detailedOpen5, detailedOpen6, formik.values.documentArticles, documentArticlesFocusedRow]);
   const debouncedHandleDetailed4Change = useMemo(
     () => debounce(detailed4SearchFormik.handleSubmit, 500),
     []
@@ -265,7 +265,7 @@ export const InputGrid = ({
       detailed5SearchFormik.setFieldValue('DetailedAccountCode', value);
       detailed5SearchFormik.setFieldValue('DetailedAccountName', '');
     }
-  };
+  }, [i18n, t, detailed6SearchIsFetching, moeinAccountOpen, detailedOpen4, detailedOpen5, detailedOpen6, formik.values.documentArticles, documentArticlesFocusedRow]);
   const debouncedHandleDetailed5Change = useMemo(
     () => debounce(detailed5SearchFormik.handleSubmit, 500),
     []
@@ -279,7 +279,7 @@ export const InputGrid = ({
       detailed6SearchFormik.setFieldValue('DetailedAccountCode', value);
       detailed6SearchFormik.setFieldValue('DetailedAccountName', '');
     }
-  };
+  }, [formik.values.documentArticles, documentArticlesFocusedRow, moeinAccountOpen, detailedOpen4, detailedOpen5, detailedOpen6]);
   const debouncedHandleDetailed6Change = useMemo(
     () => debounce(detailed6SearchFormik.handleSubmit, 500),
     []
@@ -288,7 +288,7 @@ export const InputGrid = ({
   /* -------------------------------------------------------------------------- */
 
   /* -------------------------------------------------------------------------- */
-  const CodingCell = (index) => {
+  const CodingCell = useCallback((index) => {
     return (
       <div className={`table-autocomplete position-relative`}>
         <GHAutocomplete
@@ -402,9 +402,9 @@ export const InputGrid = ({
         </Tooltip>
       </div>
     );
-  };
+  }, [formik.values.documentArticles, creditsTotal, debitsTotal]);
 
-  const detailed4Cell = (index) => {
+  const detailed4Cell = useCallback((index) => {
     return (
       <div className={`table-autocomplete position-relative`}>
         <GHAutocomplete
@@ -518,9 +518,9 @@ export const InputGrid = ({
         </Tooltip>
       </div>
     );
-  };
+  }, [formik.values.documentArticles, creditsTotal, debitsTotal, moeinAccountOpen, detailedOpen4, detailedOpen5, detailedOpen6]);
 
-  const detailed5Cell = (index) => {
+  const detailed5Cell = useCallback((index) => {
     return (
       <div className={`table-autocomplete position-relative`}>
         <GHAutocomplete
@@ -633,9 +633,9 @@ export const InputGrid = ({
         </Tooltip>
       </div>
     );
-  };
+  }, [formik.values.documentArticles, documentArticlesFocusedRow, moeinAccountOpen, detailedOpen4, detailedOpen5, detailedOpen6]);
 
-  const detailed6Cell = (index) => {
+  const detailed6Cell = useCallback((index) => {
     return (
       <div className={`table-autocomplete position-relative`}>
         <GHAutocomplete
@@ -748,9 +748,9 @@ export const InputGrid = ({
         </Tooltip>
       </div>
     );
-  };
+  }, [formik.values.documentArticles, documentArticlesFocusedRow, moeinAccountOpen]);
 
-  const debitsCell = (index) => {
+  const debitsCell = useCallback((index) => {
     return (
       <GHCurrencyInput
         onKeyDown={(e) =>
@@ -772,9 +772,9 @@ export const InputGrid = ({
         onBlur={() => CalculateDebitsTotal(formik.values.documentArticles)}
       />
     );
-  };
+  }, [formik.values.documentArticles, documentArticlesFocusedRow, moeinAccountOpen]);
 
-  const switchCell = (index) => {
+  const switchCell = useCallback((index) => {
     return (
       <IconButton
         variant="contained"
@@ -797,7 +797,7 @@ export const InputGrid = ({
     );
   };
 
-  const creditsCell = (index) => {
+  const creditsCell = useCallback((index) => {
     return (
       <GHCurrencyInput
         onKeyDown={(e) =>
@@ -821,7 +821,7 @@ export const InputGrid = ({
     );
   };
 
-  const notesCell = (index) => {
+  const notesCell = useCallback((index) => {
     return (
       <GHInput
         onKeyDown={(e) =>
@@ -843,7 +843,7 @@ export const InputGrid = ({
     );
   };
 
-  const trackingNumberCell = (index) => {
+  const trackingNumberCell = useCallback((index) => {
     return (
       <GHInput
         disabled={
@@ -870,7 +870,7 @@ export const InputGrid = ({
     );
   };
 
-  const trackingDateCell = (index) => {
+  const trackingDateCell = useCallback((index) => {
     return (
       <div
         onKeyDown={(e) => {

--- a/src/components/GHGrid/GHGrid.js
+++ b/src/components/GHGrid/GHGrid.js
@@ -8,6 +8,69 @@ import { useTheme } from "@mui/material";
 import { CreateTableError } from "../../utils/createTableError";
 import { findNextFocusable } from "../../utils/GridNavigation/GridNavigation";
 
+const GHGridRow = React.memo(function GHGridRow({
+    item,
+    index,
+    fieldArrayKey,
+    columns,
+    showDelete,
+    remove,
+    removeRowOperation,
+    rowFocusFunction,
+    rowFocusState,
+    showIndex,
+    customIndexCell,
+    disableRemoveExpr
+}) {
+    return (
+        <tr
+            style={{ cursor: 'pointer' }}
+            className={rowFocusState === index + 1 ? 'focus-row-bg' : ''}
+            onFocus={(e) => rowFocusFunction(e)}
+        >
+            {customIndexCell === null ? (
+                <td
+                    className='text-center'
+                    style={{
+                        verticalAlign: 'middle',
+                        width: '40px',
+                        display: showIndex ? 'table-cell' : 'none'
+                    }}
+                >
+                    {index + 1}
+                </td>
+            ) : (
+                customIndexCell()
+            )}
+            {columns.map((column, columnIndex) =>
+                column.show || typeof column.show === 'undefined' ? (
+                    <td
+                        key={columnIndex}
+                        style={{
+                            width: column.width ? column.width : 'auto',
+                            minWidth: column.minWidth ? column.minWidth : 'auto'
+                        }}
+                    >
+                        {column.content(index)}
+                    </td>
+                ) : null
+            )}
+            {showDelete ? (
+                <td style={{ width: '40px' }}>
+                    <input disabled hidden />
+                    <InputGridDeleteRowBtn
+                        onClick={() => {
+                            removeRowOperation(index);
+                            remove(index);
+                        }}
+                        disabled={disableRemoveExpr(index)}
+                    />
+                </td>
+            ) : null}
+        </tr>
+    );
+});
+
 const GHGrid = ({
     title,
     fieldArrayName,
@@ -86,46 +149,21 @@ const GHGrid = ({
                                     render={({ push, remove }) => (
                                         <React.Fragment>
                                             {fieldArrayValues?.map((item, arrayIndex) => (
-                                                <tr
-                                                    style={{ cursor: 'pointer' }}
+                                                <GHGridRow
                                                     key={item[fieldArrayKey]}
-                                                    className={rowFocusState === arrayIndex + 1 ? 'focus-row-bg' : ''}
-                                                    onFocus={(e) => rowFocusFunction(e)}
-                                                >
-                                                    {customIndexCell === null ?
-                                                        <td className='text-center'
-                                                            style={{
-                                                                verticalAlign: 'middle',
-                                                                width: '40px',
-                                                                display: showIndex ? 'table-cell' : 'none'
-                                                            }}>
-                                                            {arrayIndex + 1}
-                                                        </td>
-                                                        : customIndexCell()}
-                                                    {columns.map((column, index) => (
-                                                        column.show || typeof (column.show) === "undefined" ?
-                                                            <td
-                                                                key={index}
-                                                                style={{
-                                                                    width: column.width ? column.width : "auto",
-                                                                    minWidth: column.minWidth ? column.minWidth : "auto"
-                                                                }}
-                                                            >
-                                                                {column.content(arrayIndex)}
-                                                            </td> : null
-                                                    ))}
-                                                    {showDelete ?
-                                                        <td style={{ width: '40px' }}>
-                                                            <input disabled hidden />
-                                                            <InputGridDeleteRowBtn
-                                                                onClick={() => {
-                                                                    removeRowOperation(arrayIndex)
-                                                                    remove(arrayIndex)
-                                                                }}
-                                                                disabled={disableRemoveExpr(arrayIndex)}
-                                                            />
-                                                        </td> : null}
-                                                </tr>
+                                                    item={item}
+                                                    index={arrayIndex}
+                                                    fieldArrayKey={fieldArrayKey}
+                                                    columns={columns}
+                                                    showDelete={showDelete}
+                                                    remove={remove}
+                                                    removeRowOperation={removeRowOperation}
+                                                    rowFocusFunction={rowFocusFunction}
+                                                    rowFocusState={rowFocusState}
+                                                    showIndex={showIndex}
+                                                    customIndexCell={customIndexCell}
+                                                    disableRemoveExpr={disableRemoveExpr}
+                                                />
                                             ))}
                                         </React.Fragment>
                                     )}


### PR DESCRIPTION
## Summary
- add `GHGridRow` component wrapped with `React.memo`
- map table rows using `GHGridRow`
- wrap all cell renderers in `InputGrid` with `useCallback` to reduce unnecessary re-renders

## Testing
- `npm run build` *(fails: `babel: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6884913684e883219fe62fd19674ca67