### PR TITLE
Use props directly in GHAutocomplete

### DIFF
--- a/src/components/GHAutocomplete/GHAutocomplete.js
+++ b/src/components/GHAutocomplete/GHAutocomplete.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React from "react"
 import Autocomplete from "@mui/material/Autocomplete"
 import CircularProgress from "@mui/material/CircularProgress"
 const GHAutocomplete = ({
@@ -11,32 +11,27 @@ const GHAutocomplete = ({
     dir = "ltr",
     ...props
 }) => {
-    const [width, setWidth] = useState(innerWidth)
-    const [fontSize, setFontSize] = useState(innerFontSize)
-    const [bgColor, setBgColor] = useState(backgroundColor)
     return (
         <Autocomplete
             componentsProps={{
                 paper: {
                     sx: {
-                        width: { width },
+                        width: innerWidth,
                         maxWidth: '90vw',
                         direction: dir,
                         position: "absolute",
-                        fontSize: { fontSize },
+                        fontSize: innerFontSize,
                         right: dir === "rtl" ? "0" : "unset"
                     }
                 }
             }}
-            sx={
-                {
-                    direction: dir,
-                    position: "relative",
-                    background: { bgColor },
-                    borderRadius: 0,
-                    fontSize: { fontSize }
-                }
-            }
+            sx={{
+                direction: dir,
+                position: "relative",
+                background: backgroundColor,
+                borderRadius: 0,
+                fontSize: innerFontSize
+            }}
             size="small"
             isOptionEqualToValue={(option, value) => option?.value === value?.value}
             disableClearable={!allowClear}


### PR DESCRIPTION
## Summary
- remove unnecessary useState hooks from GHAutocomplete
- rely on props for styling to avoid extra renders

## Testing
- `npm run build` *(fails: `babel` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688490da20b88321923ca1c12503c746