### PR TITLE
Fix GHAutocomplete loading prop

### DIFF
--- a/src/components/GHAutocomplete/GHAutocomplete.js
+++ b/src/components/GHAutocomplete/GHAutocomplete.js
@@ -37,7 +37,7 @@ const GHAutocomplete = ({
             disableClearable={!allowClear}
             forcePopupIcon={false}
             noOptionsText={noOptionsText}
-            loading
+            loading={loadingState}
             loadingText={loadingState ? <CircularProgress /> : noOptionsText}
             renderInput={(params) => (
                 <div ref={params.InputProps.ref}>


### PR DESCRIPTION
## Summary
- conditionally show spinner in GHAutocomplete via `loading={loadingState}`

## Testing
- `npm run build` *(fails: babel not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884965078a48321adb7ab81d546d399